### PR TITLE
Update plugin description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "displayName": "Ecobee Away",
   "name": "homebridge-ecobee-away",
   "version": "1.0.2",
-  "description": "A short description about what your plugin does.",
+  "description": "Homebridge plugin to control Ecobee thermostat home/away status",
   "author": "Cory Imdieke",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
I noticed recently when installing the plugin that on the Homebridge site it still shows the default plugin description, figured it would be helpful to have something more specific.