### PR TITLE
Address 'unknown' and lint errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore compiled code
 dist
 
+# macOS generated files
+.DS_Store
+
 # ------------- Defaults ------------- #
 
 # Logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "nodemon": "^2.0.7",
         "rimraf": "^3.0.2",
         "ts-node": "^9.1.1",
-        "typescript": "^4.1.5"
+        "typescript": "^4.4"
       },
       "engines": {
         "homebridge": ">0.4.53",

--- a/package-lock.json
+++ b/package-lock.json
@@ -344,11 +344,11 @@
       }
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
+      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
   "displayName": "Ecobee Away",
   "name": "homebridge-ecobee-away",
-<<<<<<< HEAD
-  "version": "1.0.2",
-=======
   "version": "1.0.3",
->>>>>>> da3f4090bce74c7b8a5670079e87088a84893577
   "description": "Homebridge plugin to control Ecobee thermostat home/away status",
   "author": "Cory Imdieke",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "displayName": "Ecobee Away",
   "name": "homebridge-ecobee-away",
   "version": "1.0.2",
-  "description": "A short description about what your plugin does.",
+  "description": "Homebridge plugin to control Ecobee thermostat home/away status",
   "author": "Cory Imdieke",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "nodemon": "^2.0.7",
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.5"
+    "typescript": "^4.4"
   }
 }

--- a/src/auth-token-refresh.ts
+++ b/src/auth-token-refresh.ts
@@ -67,7 +67,14 @@ export class AuthTokenManager {
 
 			return loadedAuthToken;
 		} catch(error){
-			this.platform.log.error(`Error refreshing token: ${JSON.stringify(error.response.data)}`);
+			let errorMessage: string;
+			if (axios.isAxiosError(error)) {
+				errorMessage = JSON.stringify(error.response?.data);
+			} else {
+				errorMessage = JSON.stringify(error);
+			}
+
+			this.platform.log.error(`Error refreshing token: ${errorMessage}`);
 		}
 	}
 }

--- a/src/awaySwitchAccessory.ts
+++ b/src/awaySwitchAccessory.ts
@@ -121,7 +121,7 @@ export class AwaySwitchAccessory {
 
 			callback(null);
 		} catch(error){
-			callback(error);
+			callback(error as Error);
 		}
 	}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,11 @@
 import { readFileSync, writeFileSync } from 'fs';
+import { API } from 'homebridge';
 
 export interface EcobeeAwayPlatformConfig {
 	refreshToken: string
 }
 
-export function updateHomebridgeConfig(homebridge: any, update: (config: string) => string) {
+export function updateHomebridgeConfig(homebridge: API, update: (config: string) => string) {
 	const configPath = homebridge.user.configPath();
 	const config = readFileSync(configPath).toString();
 	const updatedConfig = update(config);

--- a/src/refresh-token.ts
+++ b/src/refresh-token.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-console */
-import { requestInput } from './cli-util';
-
 import axios from 'axios';
 import querystring from 'querystring';
 
@@ -41,13 +39,12 @@ async function checkForTokenResult(authCode: string, interval: number) {
 			const refreshToken = authData.refresh_token;
 
 			return { accessToken: accessToken, refreshToken: refreshToken };
-		} catch (error) {
-			if (!error.isAxiosError) {
-				// Can't get out of this one
+		} catch (error: unknown) {
+			if (!axios.isAxiosError(error)) {
 				throw error;
 			}
 			// Check error info, likely waiting for user or expired
-			const errorData = error.response.data;
+			const errorData = error.response?.data;
 			if (errorData.error === 'authorization_pending') {
 				// Wait duration and try again
 				await new Promise(resolve => setTimeout(resolve, (interval + 1) * 1000));


### PR DESCRIPTION
There was change in Typescript last year that instead of defaulting to `any`, errors in catch blocks now default to `unknown` - see [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables).

Commit da3f4090bce74c7b8a5670079e87088a84893577 updated the package lock file such that it seems like now various CI tools are pulling in the new version of typescript. I've updated the nom package file to also use at least the version of TS that introduced these issues so that it's easier to reproduce locally.

For auth-refresh-token, I opted to check for an axios error first since that was done in refresh-token.

For awaySwitchAccessory, I was a bit lazy and just treated the type as Error since that seemed to be what we basically assumed the type would have been when invoking the callback.

For refresh-token, there's a type-safe way of checking for an axios error so I switched to that (also what was used in auth-refresh-token). 

While here I addressed a couple lint issues, namely specifying a type in updateHomebridgeConfig and checking the response property on axios errors before using it.

Lastly, since I build on macOS, I added .DS_Store to be ignored by git.